### PR TITLE
Improved time performance of processor with parallelisation 

### DIFF
--- a/cdqa/reader/bertqa_sklearn.py
+++ b/cdqa/reader/bertqa_sklearn.py
@@ -26,6 +26,7 @@ import os
 import random
 import sys
 from io import open
+import uuid
 import multiprocessing as mp
 
 import numpy as np
@@ -149,7 +150,6 @@ def read_squad_examples(input_file, is_training, version_2_with_negative, n_jobs
     pool = mp.Pool(processes=processes)
     for entry in input_data:
         for paragraph in entry["paragraphs"]:
-            # list of jobs for multiprocessing
             pool.apply(
                 func=_read_paragraph,
                 args=(
@@ -253,179 +253,206 @@ def convert_examples_to_features(
     max_query_length,
     is_training,
     verbose,
+    n_jobs=-1,
 ):
     """Loads a data file into a list of `InputBatch`s."""
 
-    unique_id = 1000000000
-
-    features = []
+    # Setting managed list for multiprocessing and pool object
+    features = mp.Manager().list()
+    processes = n_jobs if n_jobs != -1 else mp.cpu_count()
+    pool = mp.Pool(processes=processes)
     for (example_index, example) in enumerate(examples):
-        query_tokens = tokenizer.tokenize(example.question_text)
-
-        if len(query_tokens) > max_query_length:
-            query_tokens = query_tokens[0:max_query_length]
-
-        tok_to_orig_index = []
-        orig_to_tok_index = []
-        all_doc_tokens = []
-        for (i, token) in enumerate(example.doc_tokens):
-            orig_to_tok_index.append(len(all_doc_tokens))
-            sub_tokens = tokenizer.tokenize(token)
-            for sub_token in sub_tokens:
-                tok_to_orig_index.append(i)
-                all_doc_tokens.append(sub_token)
-
-        tok_start_position = None
-        tok_end_position = None
-        if is_training and example.is_impossible:
-            tok_start_position = -1
-            tok_end_position = -1
-        if is_training and not example.is_impossible:
-            tok_start_position = orig_to_tok_index[example.start_position]
-            if example.end_position < len(example.doc_tokens) - 1:
-                tok_end_position = orig_to_tok_index[example.end_position + 1] - 1
-            else:
-                tok_end_position = len(all_doc_tokens) - 1
-            (tok_start_position, tok_end_position) = _improve_answer_span(
-                all_doc_tokens,
-                tok_start_position,
-                tok_end_position,
+        pool.apply(
+            func=_example_to_feature,
+            args=(
+                features,
+                example_index,
+                example,
                 tokenizer,
-                example.orig_answer_text,
-            )
-
-        # The -3 accounts for [CLS], [SEP] and [SEP]
-        max_tokens_for_doc = max_seq_length - len(query_tokens) - 3
-
-        # We can have documents that are longer than the maximum sequence length.
-        # To deal with this we do a sliding window approach, where we take chunks
-        # of the up to our max length with a stride of `doc_stride`.
-        _DocSpan = collections.namedtuple(  # pylint: disable=invalid-name
-            "DocSpan", ["start", "length"]
+                max_seq_length,
+                doc_stride,
+                max_query_length,
+                is_training,
+                verbose,
+            ),
         )
-        doc_spans = []
-        start_offset = 0
-        while start_offset < len(all_doc_tokens):
-            length = len(all_doc_tokens) - start_offset
-            if length > max_tokens_for_doc:
-                length = max_tokens_for_doc
-            doc_spans.append(_DocSpan(start=start_offset, length=length))
-            if start_offset + length == len(all_doc_tokens):
-                break
-            start_offset += min(length, doc_stride)
+    pool.close()
+    pool.join()
 
-        for (doc_span_index, doc_span) in enumerate(doc_spans):
-            tokens = []
-            token_to_orig_map = {}
-            token_is_max_context = {}
-            segment_ids = []
-            tokens.append("[CLS]")
+    return list(features)
+
+
+def _example_to_feature(
+    features,
+    example_index,
+    example,
+    tokenizer,
+    max_seq_length,
+    doc_stride,
+    max_query_length,
+    is_training,
+    verbose,
+):
+    query_tokens = tokenizer.tokenize(example.question_text)
+
+    if len(query_tokens) > max_query_length:
+        query_tokens = query_tokens[0:max_query_length]
+
+    tok_to_orig_index = []
+    orig_to_tok_index = []
+    all_doc_tokens = []
+    for (i, token) in enumerate(example.doc_tokens):
+        orig_to_tok_index.append(len(all_doc_tokens))
+        sub_tokens = tokenizer.tokenize(token)
+        for sub_token in sub_tokens:
+            tok_to_orig_index.append(i)
+            all_doc_tokens.append(sub_token)
+
+    tok_start_position = None
+    tok_end_position = None
+    if is_training and example.is_impossible:
+        tok_start_position = -1
+        tok_end_position = -1
+    if is_training and not example.is_impossible:
+        tok_start_position = orig_to_tok_index[example.start_position]
+        if example.end_position < len(example.doc_tokens) - 1:
+            tok_end_position = orig_to_tok_index[example.end_position + 1] - 1
+        else:
+            tok_end_position = len(all_doc_tokens) - 1
+        (tok_start_position, tok_end_position) = _improve_answer_span(
+            all_doc_tokens,
+            tok_start_position,
+            tok_end_position,
+            tokenizer,
+            example.orig_answer_text,
+        )
+
+    # The -3 accounts for [CLS], [SEP] and [SEP]
+    max_tokens_for_doc = max_seq_length - len(query_tokens) - 3
+
+    # We can have documents that are longer than the maximum sequence length.
+    # To deal with this we do a sliding window approach, where we take chunks
+    # of the up to our max length with a stride of `doc_stride`.
+    _DocSpan = collections.namedtuple(  # pylint: disable=invalid-name
+        "DocSpan", ["start", "length"]
+    )
+    doc_spans = []
+    start_offset = 0
+    while start_offset < len(all_doc_tokens):
+        length = len(all_doc_tokens) - start_offset
+        if length > max_tokens_for_doc:
+            length = max_tokens_for_doc
+        doc_spans.append(_DocSpan(start=start_offset, length=length))
+        if start_offset + length == len(all_doc_tokens):
+            break
+        start_offset += min(length, doc_stride)
+
+    for (doc_span_index, doc_span) in enumerate(doc_spans):
+        unique_id = uuid.uuid4().int
+        tokens = []
+        token_to_orig_map = {}
+        token_is_max_context = {}
+        segment_ids = []
+        tokens.append("[CLS]")
+        segment_ids.append(0)
+        for token in query_tokens:
+            tokens.append(token)
             segment_ids.append(0)
-            for token in query_tokens:
-                tokens.append(token)
-                segment_ids.append(0)
-            tokens.append("[SEP]")
-            segment_ids.append(0)
+        tokens.append("[SEP]")
+        segment_ids.append(0)
 
-            for i in range(doc_span.length):
-                split_token_index = doc_span.start + i
-                token_to_orig_map[len(tokens)] = tok_to_orig_index[split_token_index]
+        for i in range(doc_span.length):
+            split_token_index = doc_span.start + i
+            token_to_orig_map[len(tokens)] = tok_to_orig_index[split_token_index]
 
-                is_max_context = _check_is_max_context(
-                    doc_spans, doc_span_index, split_token_index
-                )
-                token_is_max_context[len(tokens)] = is_max_context
-                tokens.append(all_doc_tokens[split_token_index])
-                segment_ids.append(1)
-            tokens.append("[SEP]")
+            is_max_context = _check_is_max_context(
+                doc_spans, doc_span_index, split_token_index
+            )
+            token_is_max_context[len(tokens)] = is_max_context
+            tokens.append(all_doc_tokens[split_token_index])
             segment_ids.append(1)
+        tokens.append("[SEP]")
+        segment_ids.append(1)
 
-            input_ids = tokenizer.convert_tokens_to_ids(tokens)
+        input_ids = tokenizer.convert_tokens_to_ids(tokens)
 
-            # The mask has 1 for real tokens and 0 for padding tokens. Only real
-            # tokens are attended to.
-            input_mask = [1] * len(input_ids)
+        # The mask has 1 for real tokens and 0 for padding tokens. Only real
+        # tokens are attended to.
+        input_mask = [1] * len(input_ids)
 
-            # Zero-pad up to the sequence length.
-            while len(input_ids) < max_seq_length:
-                input_ids.append(0)
-                input_mask.append(0)
-                segment_ids.append(0)
+        # Zero-pad up to the sequence length.
+        while len(input_ids) < max_seq_length:
+            input_ids.append(0)
+            input_mask.append(0)
+            segment_ids.append(0)
 
-            assert len(input_ids) == max_seq_length
-            assert len(input_mask) == max_seq_length
-            assert len(segment_ids) == max_seq_length
+        assert len(input_ids) == max_seq_length
+        assert len(input_mask) == max_seq_length
+        assert len(segment_ids) == max_seq_length
 
-            start_position = None
-            end_position = None
-            if is_training and not example.is_impossible:
-                # For training, if our document chunk does not contain an annotation
-                # we throw it out, since there is nothing to predict.
-                doc_start = doc_span.start
-                doc_end = doc_span.start + doc_span.length - 1
-                out_of_span = False
-                if not (
-                    tok_start_position >= doc_start and tok_end_position <= doc_end
-                ):
-                    out_of_span = True
-                if out_of_span:
-                    start_position = 0
-                    end_position = 0
-                else:
-                    doc_offset = len(query_tokens) + 2
-                    start_position = tok_start_position - doc_start + doc_offset
-                    end_position = tok_end_position - doc_start + doc_offset
-            if is_training and example.is_impossible:
+        start_position = None
+        end_position = None
+        if is_training and not example.is_impossible:
+            # For training, if our document chunk does not contain an annotation
+            # we throw it out, since there is nothing to predict.
+            doc_start = doc_span.start
+            doc_end = doc_span.start + doc_span.length - 1
+            out_of_span = False
+            if not (tok_start_position >= doc_start and tok_end_position <= doc_end):
+                out_of_span = True
+            if out_of_span:
                 start_position = 0
                 end_position = 0
-            if example_index < 20 and verbose:
-                logger.info("*** Example ***")
-                logger.info("unique_id: %s" % (unique_id))
-                logger.info("example_index: %s" % (example_index))
-                logger.info("doc_span_index: %s" % (doc_span_index))
-                logger.info("tokens: %s" % " ".join(tokens))
-                logger.info(
-                    "token_to_orig_map: %s"
-                    % " ".join(
-                        ["%d:%d" % (x, y) for (x, y) in token_to_orig_map.items()]
-                    )
-                )
-                logger.info(
-                    "token_is_max_context: %s"
-                    % " ".join(
-                        ["%d:%s" % (x, y) for (x, y) in token_is_max_context.items()]
-                    )
-                )
-                logger.info("input_ids: %s" % " ".join([str(x) for x in input_ids]))
-                logger.info("input_mask: %s" % " ".join([str(x) for x in input_mask]))
-                logger.info("segment_ids: %s" % " ".join([str(x) for x in segment_ids]))
-                if is_training and example.is_impossible:
-                    logger.info("impossible example")
-                if is_training and not example.is_impossible:
-                    answer_text = " ".join(tokens[start_position : (end_position + 1)])
-                    logger.info("start_position: %d" % (start_position))
-                    logger.info("end_position: %d" % (end_position))
-                    logger.info("answer: %s" % (answer_text))
-
-            features.append(
-                InputFeatures(
-                    unique_id=unique_id,
-                    example_index=example_index,
-                    doc_span_index=doc_span_index,
-                    tokens=tokens,
-                    token_to_orig_map=token_to_orig_map,
-                    token_is_max_context=token_is_max_context,
-                    input_ids=input_ids,
-                    input_mask=input_mask,
-                    segment_ids=segment_ids,
-                    start_position=start_position,
-                    end_position=end_position,
-                    is_impossible=example.is_impossible,
+            else:
+                doc_offset = len(query_tokens) + 2
+                start_position = tok_start_position - doc_start + doc_offset
+                end_position = tok_end_position - doc_start + doc_offset
+        if is_training and example.is_impossible:
+            start_position = 0
+            end_position = 0
+        if example_index < 20 and verbose:
+            logger.info("*** Example ***")
+            logger.info("unique_id: %s" % (unique_id))
+            logger.info("example_index: %s" % (example_index))
+            logger.info("doc_span_index: %s" % (doc_span_index))
+            logger.info("tokens: %s" % " ".join(tokens))
+            logger.info(
+                "token_to_orig_map: %s"
+                % " ".join(["%d:%d" % (x, y) for (x, y) in token_to_orig_map.items()])
+            )
+            logger.info(
+                "token_is_max_context: %s"
+                % " ".join(
+                    ["%d:%s" % (x, y) for (x, y) in token_is_max_context.items()]
                 )
             )
-            unique_id += 1
+            logger.info("input_ids: %s" % " ".join([str(x) for x in input_ids]))
+            logger.info("input_mask: %s" % " ".join([str(x) for x in input_mask]))
+            logger.info("segment_ids: %s" % " ".join([str(x) for x in segment_ids]))
+            if is_training and example.is_impossible:
+                logger.info("impossible example")
+            if is_training and not example.is_impossible:
+                answer_text = " ".join(tokens[start_position : (end_position + 1)])
+                logger.info("start_position: %d" % (start_position))
+                logger.info("end_position: %d" % (end_position))
+                logger.info("answer: %s" % (answer_text))
 
-    return features
+        features.append(
+            InputFeatures(
+                unique_id=unique_id,
+                example_index=example_index,
+                doc_span_index=doc_span_index,
+                tokens=tokens,
+                token_to_orig_map=token_to_orig_map,
+                token_is_max_context=token_is_max_context,
+                input_ids=input_ids,
+                input_mask=input_mask,
+                segment_ids=segment_ids,
+                start_position=start_position,
+                end_position=end_position,
+                is_impossible=example.is_impossible,
+            )
+        )
 
 
 def _improve_answer_span(
@@ -1003,6 +1030,7 @@ class BertProcessor(BaseEstimator, TransformerMixin):
             max_query_length=self.max_query_length,
             is_training=self.is_training,
             verbose=self.verbose,
+            n_jobs=self.n_jobs,
         )
 
         return examples, features

--- a/cdqa/reader/bertqa_sklearn.py
+++ b/cdqa/reader/bertqa_sklearn.py
@@ -47,6 +47,7 @@ from pytorch_pretrained_bert.tokenization import (
 )
 
 from sklearn.base import BaseEstimator, TransformerMixin
+from joblib import Parallel, delayed
 
 if sys.version_info[0] == 2:
     import cPickle as pickle
@@ -133,7 +134,7 @@ class InputFeatures(object):
         self.is_impossible = is_impossible
 
 
-def read_squad_examples(input_file, is_training, version_2_with_negative):
+def read_squad_examples(input_file, is_training, version_2_with_negative, n_jobs=-1):
     """Read a SQuAD json file into a list of SquadExample."""
 
     if isinstance(input_file, str):
@@ -142,89 +143,96 @@ def read_squad_examples(input_file, is_training, version_2_with_negative):
     else:
         input_data = input_file
 
+    examples = Parallel(n_jobs=n_jobs)(
+        delayed(read_example)(entry, is_training, version_2_with_negative)
+        for entry in input_data
+    )
+    return examples
+
+
+def read_example(entry, is_training, version_2_with_negative):
+
     def is_whitespace(c):
         if c == " " or c == "\t" or c == "\r" or c == "\n" or ord(c) == 0x202F:
             return True
         return False
 
-    examples = []
-    for entry in input_data:
-        for paragraph in entry["paragraphs"]:
-            paragraph_text = paragraph["context"]
-            doc_tokens = []
-            char_to_word_offset = []
-            prev_is_whitespace = True
-            for c in paragraph_text:
-                if is_whitespace(c):
-                    prev_is_whitespace = True
+    for paragraph in entry["paragraphs"]:
+        paragraph_text = paragraph["context"]
+        doc_tokens = []
+        char_to_word_offset = []
+        prev_is_whitespace = True
+        for c in paragraph_text:
+            if is_whitespace(c):
+                prev_is_whitespace = True
+            else:
+                if prev_is_whitespace:
+                    doc_tokens.append(c)
                 else:
-                    if prev_is_whitespace:
-                        doc_tokens.append(c)
-                    else:
-                        doc_tokens[-1] += c
-                    prev_is_whitespace = False
-                char_to_word_offset.append(len(doc_tokens) - 1)
+                    doc_tokens[-1] += c
+                prev_is_whitespace = False
+            char_to_word_offset.append(len(doc_tokens) - 1)
 
-            for qa in paragraph["qas"]:
-                qas_id = qa["id"]
-                question_text = qa["question"]
-                start_position = None
-                end_position = None
-                orig_answer_text = None
-                is_impossible = False
-                if is_training:
-                    if version_2_with_negative:
-                        is_impossible = qa["is_impossible"]
-                    if (len(qa["answers"]) != 1) and (not is_impossible):
-                        raise ValueError(
-                            "For training, each question should have exactly 1 answer."
+        for qa in paragraph["qas"]:
+            qas_id = qa["id"]
+            question_text = qa["question"]
+            start_position = None
+            end_position = None
+            orig_answer_text = None
+            is_impossible = False
+            if is_training:
+                if version_2_with_negative:
+                    is_impossible = qa["is_impossible"]
+                if (len(qa["answers"]) != 1) and (not is_impossible):
+                    raise ValueError(
+                        "For training, each question should have exactly 1 answer."
+                    )
+                if not is_impossible:
+                    answer = qa["answers"][0]
+                    orig_answer_text = answer["text"]
+                    answer_offset = answer["answer_start"]
+                    answer_length = len(orig_answer_text)
+                    start_position = char_to_word_offset[answer_offset]
+                    end_position = char_to_word_offset[
+                        answer_offset + answer_length - 1
+                    ]
+                    # Only add answers where the text can be exactly recovered from the
+                    # document. If this CAN'T happen it's likely due to weird Unicode
+                    # stuff so we will just skip the example.
+                    #
+                    # Note that this means for training mode, every example is NOT
+                    # guaranteed to be preserved.
+                    actual_text = " ".join(
+                        doc_tokens[start_position : (end_position + 1)]
+                    )
+                    cleaned_answer_text = " ".join(
+                        whitespace_tokenize(orig_answer_text)
+                    )
+                    if actual_text.find(cleaned_answer_text) == -1:
+                        logger.warning(
+                            "Could not find answer: '%s' vs. '%s'",
+                            actual_text,
+                            cleaned_answer_text,
                         )
-                    if not is_impossible:
-                        answer = qa["answers"][0]
-                        orig_answer_text = answer["text"]
-                        answer_offset = answer["answer_start"]
-                        answer_length = len(orig_answer_text)
-                        start_position = char_to_word_offset[answer_offset]
-                        end_position = char_to_word_offset[
-                            answer_offset + answer_length - 1
-                        ]
-                        # Only add answers where the text can be exactly recovered from the
-                        # document. If this CAN'T happen it's likely due to weird Unicode
-                        # stuff so we will just skip the example.
-                        #
-                        # Note that this means for training mode, every example is NOT
-                        # guaranteed to be preserved.
-                        actual_text = " ".join(
-                            doc_tokens[start_position : (end_position + 1)]
-                        )
-                        cleaned_answer_text = " ".join(
-                            whitespace_tokenize(orig_answer_text)
-                        )
-                        if actual_text.find(cleaned_answer_text) == -1:
-                            logger.warning(
-                                "Could not find answer: '%s' vs. '%s'",
-                                actual_text,
-                                cleaned_answer_text,
-                            )
-                            continue
-                    else:
-                        start_position = -1
-                        end_position = -1
-                        orig_answer_text = ""
+                        continue
+                else:
+                    start_position = -1
+                    end_position = -1
+                    orig_answer_text = ""
 
-                example = SquadExample(
-                    qas_id=qas_id,
-                    question_text=question_text,
-                    doc_tokens=doc_tokens,
-                    orig_answer_text=orig_answer_text,
-                    start_position=start_position,
-                    end_position=end_position,
-                    is_impossible=is_impossible,
-                    paragraph=paragraph_text,
-                    title=entry["title"],
-                )
-                examples.append(example)
-    return examples
+            example = SquadExample(
+                qas_id=qas_id,
+                question_text=question_text,
+                doc_tokens=doc_tokens,
+                orig_answer_text=orig_answer_text,
+                start_position=start_position,
+                end_position=end_position,
+                is_impossible=is_impossible,
+                paragraph=paragraph_text,
+                title=entry["title"],
+            )
+
+    return example
 
 
 def convert_examples_to_features(
@@ -915,6 +923,9 @@ class BertProcessor(BaseEstimator, TransformerMixin):
         be truncated to this length.
     verbose : bool, optional
         If true, all of the warnings related to data processing will be printed.
+    n_jobs : int or None, optional (default=-1)
+        Number of jobs to run in parallel. 'None' means 1 unless in a
+        :obj:'joblib.parallel_backend' context. '-1' means using all processors.
 
     Returns
     -------
@@ -942,6 +953,7 @@ class BertProcessor(BaseEstimator, TransformerMixin):
         max_query_length=64,
         verbose=False,
         tokenizer=None,
+        n_jobs=-1,
     ):
 
         self.bert_model = bert_model
@@ -952,6 +964,7 @@ class BertProcessor(BaseEstimator, TransformerMixin):
         self.doc_stride = doc_stride
         self.max_query_length = max_query_length
         self.verbose = verbose
+        self.n_jobs = n_jobs
 
         if tokenizer is None:
             self.tokenizer = BertTokenizer.from_pretrained(
@@ -969,6 +982,7 @@ class BertProcessor(BaseEstimator, TransformerMixin):
             input_file=X,
             is_training=self.is_training,
             version_2_with_negative=self.version_2_with_negative,
+            n_jobs=self.n_jobs,
         )
 
         features = convert_examples_to_features(

--- a/cdqa/reader/bertqa_sklearn.py
+++ b/cdqa/reader/bertqa_sklearn.py
@@ -144,13 +144,13 @@ def read_squad_examples(input_file, is_training, version_2_with_negative, n_jobs
         input_data = input_file
 
     examples = Parallel(n_jobs=n_jobs)(
-        delayed(read_example)(entry, is_training, version_2_with_negative)
+        delayed(_read_example)(entry, is_training, version_2_with_negative)
         for entry in input_data
     )
     return examples
 
 
-def read_example(entry, is_training, version_2_with_negative):
+def _read_example(entry, is_training, version_2_with_negative):
 
     def is_whitespace(c):
         if c == " " or c == "\t" or c == "\r" or c == "\n" or ord(c) == 0x202F:
@@ -416,7 +416,6 @@ def convert_examples_to_features(
             unique_id += 1
 
     return features
-
 
 def _improve_answer_span(
     doc_tokens, input_start, input_end, tokenizer, orig_answer_text

--- a/cdqa/retriever/tfidf_sklearn.py
+++ b/cdqa/retriever/tfidf_sklearn.py
@@ -70,7 +70,7 @@ class TfidfRetriever(BaseEstimator):
 
     Examples
     --------
-    >>> from cdqa.retriever.tfidf_retriever_sklearn import TfidfRetriever
+    >>> from cdqa.retriever.tfidf_sklearn import TfidfRetriever
 
     >>> retriever = TfidfRetriever(ngram_range=(1, 2), max_df=0.85, stop_words='english')
     >>> retriever.fit(X=df['content'])

--- a/examples/tutorial-train-reader-squad.ipynb
+++ b/examples/tutorial-train-reader-squad.ipynb
@@ -35,9 +35,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/andre.farias/python3.7.0/lib/python3.7/site-packages/sklearn/externals/joblib/__init__.py:15: DeprecationWarning: sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23. Please import this functionality directly from joblib, which can be installed with: pip install joblib. If this warning is raised when loading pickled models, you may need to re-serialize those models with scikit-learn 0.21+.\n",
+      "/home/supercalculateur/source/andre/cdqa-dev/env-cdqa/lib/python3.6/site-packages/sklearn/externals/joblib/__init__.py:15: DeprecationWarning: sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23. Please import this functionality directly from joblib, which can be installed with: pip install joblib. If this warning is raised when loading pickled models, you may need to re-serialize those models with scikit-learn 0.21+.\n",
       "  warnings.warn(msg, category=DeprecationWarning)\n",
-      "/Users/andre.farias/python3.7.0/lib/python3.7/site-packages/tqdm/autonotebook/__init__.py:18: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "/home/supercalculateur/source/andre/cdqa-dev/env-cdqa/lib/python3.6/site-packages/tqdm/autonotebook/__init__.py:18: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
       "  \" (e.g. in jupyter console)\", TqdmExperimentalWarning)\n"
      ]
     }
@@ -72,8 +72,12 @@
      "output_type": "stream",
      "text": [
       "Downloading SQuAD v1.1 data...\n",
+      "train-v1.1.json already downloaded\n",
+      "dev-v1.1.json already downloaded\n",
       "\n",
-      "Downloading SQuAD v2.0 data...\n"
+      "Downloading SQuAD v2.0 data...\n",
+      "train-v2.0.json already downloaded\n",
+      "dev-v2.0.json already downloaded\n"
      ]
     }
    ],
@@ -90,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-07-20T13:58:36.512980Z",
@@ -99,7 +103,7 @@
    },
    "outputs": [],
    "source": [
-    "train_processor = BertProcessor(do_lower_case=True, is_training=True)\n",
+    "train_processor = BertProcessor(do_lower_case=True, is_training=True, n_jobs=-1)\n",
     "train_examples, train_features = train_processor.fit_transform(X='./data/SQuAD_1.1/train-v1.1.json')"
    ]
   },
@@ -176,7 +180,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.6.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,36 @@
+from cdqa.utils.download import *
+from cdqa.reader.bertqa_sklearn import convert_examples_to_features, read_squad_examples
+from cdqa.reader.bertqa_sklearn import BertTokenizer
+
+
+def test_processor_functions():
+
+    download_squad(dir="./data")
+
+    tokenizer = BertTokenizer.from_pretrained("bert-base-uncased", do_lower_case=True)
+    max_seq_length = 256
+    max_query_length = 32
+    doc_stride = 128
+    is_training = False
+    verbose = False
+    n_jobs = -1
+
+    examples = read_squad_examples(
+        "./data/SQuAD_1.1/dev-v1.1.json",
+        is_training=is_training,
+        version_2_with_negative=False,
+        n_jobs=n_jobs,
+    )
+    assert len(examples) == 10570
+
+    features = convert_examples_to_features(
+        examples,
+        tokenizer,
+        max_seq_length,
+        doc_stride,
+        max_query_length,
+        is_training,
+        verbose,
+        n_jobs=n_jobs,
+    )
+    assert len(features) == 12006


### PR DESCRIPTION
Time execution of processing in [one of the official examples](https://github.com/cdqa-suite/cdQA/blob/master/examples/tutorial-train-reader-squad.ipynb) improved from 4min19s to 0.56s in a machine with 16 cpu cores.

This solves #216