### PR TITLE
Added functionallity to send model to GPU automatically 

### DIFF
--- a/cdqa/pipeline/cdqa_sklearn.py
+++ b/cdqa/pipeline/cdqa_sklearn.py
@@ -91,6 +91,9 @@ class QAPipeline(BaseEstimator):
 
         self.retrieve_by_doc = retrieve_by_doc
 
+        if torch.cuda.is_available:
+            self.cuda()
+
     def fit_retriever(self, df: pd.DataFrame = None):
         """ Fit the QAPipeline retriever to a list of documents in a dataframe.
         Parameters

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -49,8 +49,6 @@ def test_evaluate_pipeline():
 
     cdqa_pipeline = QAPipeline(reader="./models/bert_qa_vCPU-sklearn.joblib", n_jobs=-1)
     cdqa_pipeline.fit_retriever(df)
-    if torch.cuda.is_available():
-        cdqa_pipeline.cuda()
 
     eval_dict = evaluate_pipeline(cdqa_pipeline, "./test_data.json", output_dir=None)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -18,8 +18,7 @@ def execute_pipeline(query, n_predictions=None):
 
     cdqa_pipeline = QAPipeline(reader="models/bert_qa_vCPU-sklearn.joblib")
     cdqa_pipeline.fit_retriever(df)
-    if torch.cuda.is_available():
-        cdqa_pipeline.cuda()
+    
     if n_predictions is not None:
         predictions = cdqa_pipeline.predict(query, n_predictions=n_predictions)
         result = []


### PR DESCRIPTION
This PR adds the functionality of sending the models to GPU automatically when creating a cdqa pipeline instance, if CUDA is avaiable.

With this functionality, we can eliminate the need for storing 2 versions of the same model (CPU and GPU). After this, we will need to have only a CPU version.

